### PR TITLE
Implement the --optimize flag in crawl mode

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -63,6 +63,10 @@ pub enum Subcommand {
         #[structopt(name = "DIR", parse(from_os_str))]
         directory: PathBuf,
 
+        /// Try to find the location of a license within the given file
+        #[structopt(long = "optimize", short = "o")]
+        optimize: bool,
+
         /// Follow symlinks
         #[structopt(long = "follow")]
         follow_links: bool,

--- a/cli/src/crawl.rs
+++ b/cli/src/crawl.rs
@@ -14,6 +14,7 @@ pub fn crawl(
     cache_filename: &Path,
     output_format: &OutputFormat,
     directory: &Path,
+    optimize: bool,
     follow_links: bool,
     glob: Option<&str>,
 ) -> Result<(), Error> {
@@ -56,7 +57,7 @@ pub fn crawl(
             match read_to_string(path) {
                 Ok(content) => {
                     let data = TextData::new(&content);
-                    let idres = identify_data(&store, &data, false, false);
+                    let idres = identify_data(&store, &data, optimize, false);
                     let fileres = FileResult::from_identification_result(&path_lossy, &idres);
                     fileres.print_as(&output_format, true);
                 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -39,12 +39,14 @@ fn main() {
         } => identify::identify(&cache_file, &output_format, filename, optimize, diff, batch),
         Subcommand::Crawl {
             directory,
+            optimize,
             follow_links,
             glob,
         } => crawl::crawl(
             &cache_file,
             &output_format,
             &directory,
+            optimize,
             follow_links,
             glob.as_ref().map(String::as_str),
         ),


### PR DESCRIPTION
Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>

*Issue #, if available:*
Issue #27

*Description of changes:*
Add the optimize flag to crawl mode

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


We *may* be interested in replacing our Perl script called licensecheck (https://metacpan.org/pod/App::Licensecheck) with askalono in our package review tool. Currently licensecheck detect license header in various files, it would be great for askalono to support it in crawl mode too.