### PR TITLE
replace `failure` crate with `anyhow`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = [
 ]
 
 [dependencies]
-failure = "0.1.5"
+anyhow = "1.0.44"
 lazy_static = "1.3.0"
 log = "0.4.6"
 regex = "1.1.7"

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,10 +27,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+
+[[package]]
 name = "askalono"
 version = "0.4.3"
 dependencies = [
- "failure",
+ "anyhow",
  "flate2",
  "lazy_static",
  "log",
@@ -56,11 +53,11 @@ dependencies = [
 name = "askalono-cli"
 version = "0.4.3"
 dependencies = [
+ "anyhow",
  "askalono",
  "clap",
  "difference",
  "env_logger",
- "failure",
  "ignore",
  "log",
  "rayon",
@@ -86,20 +83,6 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
-name = "backtrace"
-version = "0.3.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "bitflags"
@@ -234,28 +217,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2 1.0.21",
- "quote 1.0.7",
- "syn 1.0.41",
- "synstructure",
-]
-
-[[package]]
 name = "flate2"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,12 +233,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "gimli"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "globset"
@@ -424,12 +379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
-
-[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,12 +485,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,18 +583,6 @@ checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "unicode-xid 0.2.1",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
-dependencies = [
- "proc-macro2 1.0.21",
- "quote 1.0.7",
- "syn 1.0.41",
  "unicode-xid 0.2.1",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 askalono = { version = "0.4.3", path = "../" }
 clap = "2.32.0"
 env_logger = "0.7"
-failure = "0.1.5"
+anyhow = "1.0.44"
 ignore = "0.4.6"
 log = "0.4.6"
 rayon = "1.0.3"

--- a/cli/src/cache.rs
+++ b/cli/src/cache.rs
@@ -3,7 +3,7 @@
 
 use std::{fs::File, path::Path};
 
-use failure::Error;
+use anyhow::Error;
 use log::info;
 
 use super::commands::*;

--- a/cli/src/crawl.rs
+++ b/cli/src/crawl.rs
@@ -3,7 +3,7 @@
 
 use std::{fs::read_to_string, path::Path};
 
-use failure::Error;
+use anyhow::Error;
 use ignore::Error as IgnoreError;
 
 use askalono::TextData;

--- a/cli/src/formats.rs
+++ b/cli/src/formats.rs
@@ -3,7 +3,7 @@
 
 use std::{fmt, fmt::Display};
 
-use failure::Error;
+use anyhow::Error;
 use serde_derive::Serialize;
 
 use super::commands::*;

--- a/cli/src/identify.rs
+++ b/cli/src/identify.rs
@@ -8,7 +8,7 @@ use std::{
     time::Instant,
 };
 
-use failure::{err_msg, Error};
+use anyhow::{format_err, Error};
 use log::info;
 
 use super::{commands::*, formats::*, util::*};
@@ -145,7 +145,7 @@ pub fn identify_data(
         return Ok(output);
     }
 
-    Err(err_msg(
+    Err(format_err!(
         "Confidence threshold not high enough for any known license",
     ))
 }

--- a/cli/src/util.rs
+++ b/cli/src/util.rs
@@ -3,7 +3,7 @@
 
 use std::path::Path;
 
-use failure::Error;
+use anyhow::Error;
 
 use askalono::{Store, TextData};
 

--- a/extras/lambda/Cargo.lock
+++ b/extras/lambda/Cargo.lock
@@ -18,10 +18,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+
+[[package]]
 name = "askalono"
 version = "0.4.3"
 dependencies = [
- "failure",
+ "anyhow",
  "flate2",
  "lazy_static",
  "log",
@@ -216,9 +222,9 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "failure"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 dependencies = [
  "backtrace",
  "failure_derive",
@@ -226,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "failure_derive"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.6",
  "quote 1.0.2",

--- a/extras/wasm/Cargo.lock
+++ b/extras/wasm/Cargo.lock
@@ -18,10 +18,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+
+[[package]]
 name = "askalono"
 version = "0.4.3"
 dependencies = [
- "failure",
+ "anyhow",
  "flate2",
  "lazy_static",
  "log",
@@ -55,29 +61,6 @@ name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-
-[[package]]
-name = "backtrace"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
-dependencies = [
- "backtrace-sys",
- "cfg-if",
- "libc",
- "rustc-demangle",
- "winapi",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "bumpalo"
@@ -175,28 +158,6 @@ name = "either"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
-
-[[package]]
-name = "failure"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
-dependencies = [
- "proc-macro2 0.4.20",
- "quote 0.6.9",
- "syn 0.15.29",
- "synstructure",
-]
 
 [[package]]
 name = "flate2"
@@ -407,12 +368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
-
-[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,7 +426,7 @@ checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
  "proc-macro2 1.0.7",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn",
 ]
 
 [[package]]
@@ -493,17 +448,6 @@ checksum = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 
 [[package]]
 name = "syn"
-version = "0.15.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
-dependencies = [
- "proc-macro2 0.4.20",
- "quote 0.6.9",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4ff033220a41d1a57d8125eab57bf5263783dfdcc18688b1dacc6ce9651ef8"
@@ -511,18 +455,6 @@ dependencies = [
  "proc-macro2 1.0.7",
  "quote 1.0.2",
  "unicode-xid 0.2.0",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
-dependencies = [
- "proc-macro2 0.4.20",
- "quote 0.6.9",
- "syn 0.15.29",
- "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -588,7 +520,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.7",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -621,7 +553,7 @@ checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
  "proc-macro2 1.0.7",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -656,28 +588,6 @@ dependencies = [
  "proc-macro2 0.4.20",
  "quote 0.6.9",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zstd"

--- a/src/store/base.rs
+++ b/src/store/base.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use failure::{format_err, Error};
+use anyhow::{format_err, Error};
 use serde::{Deserialize, Serialize};
 
 use crate::{license::LicenseType, license::TextData};

--- a/src/store/cache.rs
+++ b/src/store/cache.rs
@@ -3,7 +3,7 @@
 
 use std::{io::copy, io::prelude::*};
 
-use failure::Error;
+use anyhow::Error;
 use log::info;
 use rmp_serde::Serializer;
 use serde::Serialize;
@@ -28,7 +28,7 @@ impl Store {
         readable.read_exact(&mut header)?;
 
         if header != CACHE_VERSION {
-            failure::bail!("cache version mismatch");
+            anyhow::bail!("cache version mismatch");
         }
 
         #[cfg(not(feature = "gzip"))]

--- a/src/store/spdx.rs
+++ b/src/store/spdx.rs
@@ -8,7 +8,7 @@ use std::{
     path::Path,
 };
 
-use failure::{format_err, Error};
+use anyhow::{format_err, Error};
 use log::{debug, info};
 
 use crate::{

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -4,7 +4,7 @@
 use std::borrow::Cow;
 use std::fmt;
 
-use failure::Error;
+use anyhow::Error;
 use log::{info, trace};
 use serde::Serialize;
 


### PR DESCRIPTION
*Issue #, if available:* closes #67

*Description of changes:*
There's a call of `err_msg` with no formatting, which I replaced with `format_err!` for consistency with other imports. Perhaps we can add `result.score` there?

The `lambda` dep-tree still pulls in `failure`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Please apply label "hacktoberfest-accepted" if you approve, thanks in advance!