### PR TITLE
Update to zstd 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde_json = { version = "1.0.39", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rayon = "1.2"
-zstd = "0.9"
+zstd = "0.10"
 flate2 = { version = "1.0.14", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde_json = { version = "1.0.39", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rayon = "1.2"
-zstd = "0.10"
+zstd = "0.11"
 flate2 = { version = "1.0.14", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
*Description of changes:* 

Update zstd dependency to newest version 0.11.x.

My last pull request #72 bumped it to 0.9.x. In the meantime while the pull request was awaiting merging, 0.11.x was released, which I didn't notice. So apologies for the double pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
