### PR TITLE
Includes versions in cache version mismatch error

### DIFF
--- a/src/store/cache.rs
+++ b/src/store/cache.rs
@@ -28,7 +28,11 @@ impl Store {
         readable.read_exact(&mut header)?;
 
         if header != CACHE_VERSION {
-            anyhow::bail!("cache version mismatch");
+            anyhow::bail!(
+                "cache version mismatch; expected '{}', found '{}'",
+                String::from_utf8_lossy(CACHE_VERSION),
+                String::from_utf8_lossy(&header)
+            );
         }
 
         #[cfg(not(feature = "gzip"))]


### PR DESCRIPTION
I had an issue where my cache file was invalid,
and this helped figure out the problem (wrong download URL).
It would of course also help
if it was really just a mismatched version issue.

By submitting this pull request,
I confirm that my contribution is made
under the terms of the Apache 2.0 license.