### PR TITLE
Bump zstd from 0.11 to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde_json = { version = "1.0.39", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rayon = "1.2"
-zstd = "0.11"
+zstd = "0.13"
 flate2 = { version = "1.0.14", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
*Issue #, if available:*

**N/A**

*Description of changes:*

Update dependency on `zstd` from 0.11 to 0.13.

I confirmed that `cargo test` still passes.

See also https://github.com/jpeddicord/askalono/pull/92.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
